### PR TITLE
Add error redirect

### DIFF
--- a/src/main/java/edu/wisc/my/personalizedredirection/Application.java
+++ b/src/main/java/edu/wisc/my/personalizedredirection/Application.java
@@ -4,6 +4,8 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.web.support.SpringBootServletInitializer;
 
+
+
 @SpringBootApplication
 public class Application extends SpringBootServletInitializer {
 
@@ -12,3 +14,5 @@ public class Application extends SpringBootServletInitializer {
     }
 
 }
+
+

--- a/src/main/java/edu/wisc/my/personalizedredirection/controller/PersonalizedRedirectionController.java
+++ b/src/main/java/edu/wisc/my/personalizedredirection/controller/PersonalizedRedirectionController.java
@@ -50,6 +50,7 @@ public class PersonalizedRedirectionController {
     public @ResponseBody void getUrl(HttpServletRequest request,
             HttpServletResponse response, @PathVariable String appName) {
 
+        boolean hasError = false;
         String errorURL = "/404.html";
 
         logger.trace(
@@ -61,6 +62,7 @@ public class PersonalizedRedirectionController {
             if (dataSource == null) {
                 logger.error("No data source retrieved for " + appName);
                 response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                hasError = true;
             }
 
             String url = "";
@@ -70,6 +72,7 @@ public class PersonalizedRedirectionController {
             if (url == null || url.length() == 0) {
             	logger.error("No url found for app " + appName);
                 response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+                hasError = true;
             } else {
                 response.setStatus(HttpServletResponse.SC_OK);
             	response.sendRedirect(url);
@@ -79,7 +82,13 @@ public class PersonalizedRedirectionController {
             logger.error("Issues happened while trying to generate custom link",
                     e);
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
+            hasError = true;
          }
+
+         if(hasError){
+            response.sendRedirect(errorURL);
+         }
+
     }
     
     /**

--- a/src/main/java/edu/wisc/my/personalizedredirection/controller/PersonalizedRedirectionController.java
+++ b/src/main/java/edu/wisc/my/personalizedredirection/controller/PersonalizedRedirectionController.java
@@ -50,8 +50,6 @@ public class PersonalizedRedirectionController {
     public @ResponseBody void getUrl(HttpServletRequest request,
             HttpServletResponse response, @PathVariable String appName) {
 
-        boolean hasError = false;
-        String errorURL = "/404.html";
 
         logger.trace(
                 "Calling PersonalizedRedirectionController " + appName);
@@ -62,7 +60,6 @@ public class PersonalizedRedirectionController {
             if (dataSource == null) {
                 logger.error("No data source retrieved for " + appName);
                 response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-                hasError = true;
             }
 
             String url = "";
@@ -72,7 +69,6 @@ public class PersonalizedRedirectionController {
             if (url == null || url.length() == 0) {
             	logger.error("No url found for app " + appName);
                 response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-                hasError = true;
             } else {
                 response.setStatus(HttpServletResponse.SC_OK);
             	response.sendRedirect(url);
@@ -82,16 +78,6 @@ public class PersonalizedRedirectionController {
             logger.error("Issues happened while trying to generate custom link",
                     e);
             response.setStatus(HttpServletResponse.SC_NOT_FOUND);
-            hasError = true;
-         }
-
-         try{
-             if(hasError){
-                 response.sendRedirect(errorURL);
-             }
-         }catch(IOException e){
-             logger.error("IO EXCEPTION THROWN WHILE ATTEMPTING REDIRECT TO ERROR URL");
-             logger.error("App name = " + appName);
          }
     }
     

--- a/src/main/java/edu/wisc/my/personalizedredirection/controller/PersonalizedRedirectionController.java
+++ b/src/main/java/edu/wisc/my/personalizedredirection/controller/PersonalizedRedirectionController.java
@@ -85,10 +85,14 @@ public class PersonalizedRedirectionController {
             hasError = true;
          }
 
-         if(hasError){
-            response.sendRedirect(errorURL);
+         try{
+             if(hasError){
+                 response.sendRedirect(errorURL);
+             }
+         }catch(IOException e){
+             logger.error("IO EXCEPTION THROWN WHILE ATTEMPTING REDIRECT TO ERROR URL");
+             logger.error("App name = " + appName);
          }
-
     }
     
     /**


### PR DESCRIPTION
Just sending back a not found status results in a suboptimal error experience for the user. Adding in an explicit redirect to the root 404 page.